### PR TITLE
Normalized entropy if some symbols do not appear

### DIFF
--- a/R/entropy.R
+++ b/R/entropy.R
@@ -1,8 +1,9 @@
 entropy <-
 function(dist)
 {
+	n <- length(dist)
 	dist <- dist[dist!=0]
 	if (length(dist)==1) return (0);
-	return(-sum(dist*log(dist))/log(length(dist)));
+	return(-sum(dist*log(dist))/log(n));
 	
 }


### PR DESCRIPTION
The current calculation of the normalized entropy uses the number of symbols present in the time series:
https://github.com/brandmaier/pdc/blob/bc71af4f88f231797bc1f168558402f0f415424d/R/entropy.R#L6
where `dist` has been truncated to non-zero values (existent symbols):
https://github.com/brandmaier/pdc/blob/bc71af4f88f231797bc1f168558402f0f415424d/R/entropy.R#L4
 To  include the symbols that do not appear in the series we can use the original length of `dist`, matching the definition in section 2.2 "Entropy heuristic" of Brandmaier et al., 2015.  
 
 Thanks for your consideration and the fantastic package.